### PR TITLE
feat: independent verifier gate (#96)

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	occ "github.com/talk/opencode-client/internal/opencode"
 	"github.com/talk/opencode-client/internal/types"
 )
 
@@ -26,7 +27,8 @@ type runConfig struct {
 	baseBranch     string
 	createBranch   bool
 	validateIssues bool
-	minConfidence  string
+	minConfidence    string
+	verifierModelNum int
 }
 
 func (c runConfig) needsGitHubClient() bool {
@@ -72,7 +74,11 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	return executeReviewLoop(env, ghCtx, selected, cfg)
+	verifier, err := resolveVerifierModel(env, cfg)
+	if err != nil {
+		return err
+	}
+	return executeReviewLoop(env, ghCtx, selected, verifier, cfg)
 }
 
 func parseFlags() runConfig {
@@ -93,6 +99,7 @@ func parseFlags() runConfig {
 	createBranch := flag.Bool("create-branch", false, "Create a new fix branch from current HEAD and push before opening PR")
 	validateIssues := flag.Bool("validate-issues", false, "Check open issues against current code and close stale ones before fixing")
 	minConfidence := flag.String("min-confidence", "MEDIUM", "Minimum confidence level to auto-fix: HIGH, MEDIUM, or LOW")
+	verifierModelNum := flag.Int("verifier-model", 0, "Model number to use as independent fix verifier (0 = disabled)")
 	flag.Parse()
 
 	return runConfig{
@@ -112,8 +119,27 @@ func parseFlags() runConfig {
 		baseBranch:     *baseBranch,
 		createBranch:   *createBranch,
 		validateIssues: *validateIssues,
-		minConfidence:  *minConfidence,
+		minConfidence:    *minConfidence,
+		verifierModelNum: *verifierModelNum,
 	}
+}
+
+// resolveVerifierModel returns the ModelInfo for the verifier if --verifier-model
+// is set, or a zero-value ModelInfo (disabled) if not.
+func resolveVerifierModel(env runEnvironment, cfg runConfig) (types.ModelInfo, error) {
+	if cfg.verifierModelNum == 0 {
+		return types.ModelInfo{}, nil
+	}
+	models, err := occ.ListModels(env.client, env.ctx, env.repoRoot)
+	if err != nil {
+		return types.ModelInfo{}, fmt.Errorf("verifier model: %w", err)
+	}
+	if cfg.verifierModelNum < 1 || cfg.verifierModelNum > len(models) {
+		return types.ModelInfo{}, fmt.Errorf("verifier model: invalid number %d (have %d models)", cfg.verifierModelNum, len(models))
+	}
+	m := models[cfg.verifierModelNum-1]
+	fmt.Printf("Verifier: [%d] %s / %s\n\n", cfg.verifierModelNum, m.ProviderName, m.ModelName)
+	return m, nil
 }
 
 func normalizeLoopFlags(loopMode, mergeOnApprove, autoFix *bool, loopInterval *time.Duration) {

--- a/cli/cmd/run_loop.go
+++ b/cli/cmd/run_loop.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/talk/opencode-client/internal/git"
@@ -20,13 +21,14 @@ type iterationResult struct {
 	verdict    string
 }
 
-func executeReviewLoop(env runEnvironment, ghCtx githubContext, selected types.ModelInfo, cfg runConfig) error {
-	runner := newLoopRunner(env, ghCtx, selected, cfg, []LoopStep{
+func executeReviewLoop(env runEnvironment, ghCtx githubContext, selected, verifier types.ModelInfo, cfg runConfig) error {
+	runner := newLoopRunner(env, ghCtx, selected, verifier, cfg, []LoopStep{
 		reviewStep{},
 		postReviewStep{},
 		issueStep{},
 		mergeStep{},
 		autoFixStep{},
+		verifyFixStep{},
 		waitStep{},
 	})
 	return runner.Run()
@@ -40,11 +42,13 @@ type loopState struct {
 	env          runEnvironment
 	ghCtx        githubContext
 	selected     types.ModelInfo
+	verifier     types.ModelInfo
 	cfg          runConfig
 	iteration    int
 	result       iterationResult
 	openIssues   []int
 	changedFiles map[string]bool
+	lastFixPaths []string
 	stop         bool
 }
 
@@ -53,9 +57,9 @@ type loopRunner struct {
 	steps []LoopStep
 }
 
-func newLoopRunner(env runEnvironment, ghCtx githubContext, selected types.ModelInfo, cfg runConfig, steps []LoopStep) *loopRunner {
+func newLoopRunner(env runEnvironment, ghCtx githubContext, selected, verifier types.ModelInfo, cfg runConfig, steps []LoopStep) *loopRunner {
 	return &loopRunner{
-		state: loopState{env: env, ghCtx: ghCtx, selected: selected, cfg: cfg},
+		state: loopState{env: env, ghCtx: ghCtx, selected: selected, verifier: verifier, cfg: cfg},
 		steps: steps,
 	}
 }
@@ -148,13 +152,13 @@ func (mergeStep) Run(state *loopState) (bool, error) {
 type autoFixStep struct{}
 
 func (autoFixStep) Run(state *loopState) (bool, error) {
+	state.lastFixPaths = nil
 	if !state.cfg.autoFix {
 		return false, nil
 	}
 	findings := review.ParseFindings(state.result.reviewText)
 	fixable := filterFixableFindings(findings, state.cfg.minConfidence)
-	hasFixable := len(fixable) > 0
-	if len(findings) > 0 && !hasFixable {
+	if len(findings) > 0 && len(fixable) == 0 {
 		fmt.Fprintln(os.Stderr, "\nAuto-fix: no fixable findings at required confidence — cannot auto-fix. Manual intervention required.")
 		state.stop = true
 		return false, nil
@@ -165,8 +169,53 @@ func (autoFixStep) Run(state *loopState) (bool, error) {
 	}
 	if len(changedPaths) > 0 {
 		state.changedFiles = pathsToRelMap(changedPaths, state.env.repoRoot)
+		state.lastFixPaths = changedPaths
 	}
 	return cont, nil
+}
+
+type verifyFixStep struct{}
+
+func (verifyFixStep) Run(state *loopState) (bool, error) {
+	if state.verifier.ModelID == "" || len(state.lastFixPaths) == 0 {
+		return false, nil
+	}
+	diff, err := git.DiffHead(state.env.repoRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\nVerifier: could not get diff: %v — skipping verification\n", err)
+		return false, nil
+	}
+	findings := review.ParseFindings(state.result.reviewText)
+	fixable := filterFixableFindings(findings, state.cfg.minConfidence)
+	prompt := review.BuildVerifyPrompt(diff, buildFindingSummary(fixable))
+
+	fmt.Println("\n--- Independent Verification ---")
+	verifyText, err := occ.RunVerify(state.env.client, state.env.ctx, state.env.repoRoot, state.verifier, prompt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Verifier: session error: %v — treating as FAIL\n", err)
+		verifyText = "FAIL — verifier session error"
+	}
+
+	verdict := review.ExtractVerifyVerdict(verifyText)
+	logEvent(state.env.log, map[string]any{
+		"event":          "verify_fix",
+		"iteration":      state.iteration,
+		"verify_verdict": verdict,
+	})
+
+	if verdict == "PASS" {
+		fmt.Println("\nVerification: PASS — fix accepted.")
+		return false, nil
+	}
+
+	fmt.Fprintln(os.Stderr, "\nVerification: FAIL — reverting fix commit.")
+	if err := git.RevertHead(state.env.repoRoot); err != nil {
+		return false, fmt.Errorf("verifier: revert failed: %w", err)
+	}
+	logEvent(state.env.log, map[string]any{"event": "verify_fix_reverted", "iteration": state.iteration})
+	state.lastFixPaths = nil
+	state.changedFiles = nil
+	return true, nil
 }
 
 type waitStep struct{}
@@ -246,6 +295,17 @@ func filterFixableFindings(findings []types.Finding, minConfidence string) []typ
 		}
 	}
 	return fixable
+}
+
+func buildFindingSummary(findings []types.Finding) string {
+	var sb strings.Builder
+	for _, f := range findings {
+		fmt.Fprintf(&sb, "[%s] %s:%s — %s\n", f.Severity, f.File, f.LineRange, f.Title)
+		if f.Description != "" {
+			fmt.Fprintf(&sb, "  %s\n", strings.TrimSpace(f.Description))
+		}
+	}
+	return sb.String()
 }
 
 func pathsToRelMap(paths []string, repoRoot string) map[string]bool {

--- a/cli/internal/git/git.go
+++ b/cli/internal/git/git.go
@@ -110,6 +110,26 @@ func IsOperationalArtifact(path string) bool {
 	return strings.HasPrefix(p, "logs/")
 }
 
+// DiffHead returns the stat+patch output of the current HEAD commit.
+func DiffHead(repoRoot string) (string, error) {
+	return Run(repoRoot, "show", "--stat", "--patch", "HEAD")
+}
+
+// RevertHead creates a revert commit for HEAD and pushes it to origin.
+func RevertHead(repoRoot string) error {
+	if _, err := Run(repoRoot, "revert", "HEAD", "--no-edit"); err != nil {
+		return fmt.Errorf("git revert HEAD: %w", err)
+	}
+	branch, err := Run(repoRoot, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return fmt.Errorf("git branch name: %w", err)
+	}
+	if _, err := Run(repoRoot, "push", "origin", branch); err != nil {
+		return fmt.Errorf("git push after revert: %w", err)
+	}
+	return nil
+}
+
 func FixerStagePaths(before, after map[string]StatusSnapshotEntry) []string {
 	var paths []string
 	for path, afterStatus := range after {

--- a/cli/internal/opencode/client.go
+++ b/cli/internal/opencode/client.go
@@ -174,6 +174,11 @@ func RunReview(client *sdk.Client, ctx context.Context, repoRoot string, selecte
 	return streamSession(client, ctx, repoRoot, selected, prompt, os.Stdout)
 }
 
+// RunVerify sends a verification prompt to the verifier model and returns the full response.
+func RunVerify(client *sdk.Client, ctx context.Context, repoRoot string, verifier types.ModelInfo, prompt string) (string, error) {
+	return streamSession(client, ctx, repoRoot, verifier, prompt, os.Stdout)
+}
+
 // RunFix sends fix prompts for all findings, commits and pushes any changes.
 // Returns the number of findings sent for fixing.
 type FixPersister interface {

--- a/cli/internal/review/prompt.go
+++ b/cli/internal/review/prompt.go
@@ -19,6 +19,41 @@ func findingsFormat(sb *strings.Builder) {
 	sb.WriteString("If there are no issues: write `_No issues found._` and skip subsections.\n\n")
 }
 
+// BuildVerifyPrompt builds a short focused prompt asking a second model to
+// verify whether a fix diff correctly addresses the stated findings.
+func BuildVerifyPrompt(diff, findings string) string {
+	var sb strings.Builder
+	sb.WriteString("You are an independent code reviewer. A previous model applied automated fixes.\n")
+	sb.WriteString("Your job: verify whether those fixes are correct and complete.\n\n")
+	sb.WriteString("Respond with EXACTLY one of:\n\n")
+	sb.WriteString("  PASS — <one sentence: why the fix is correct>\n")
+	sb.WriteString("  FAIL — <one sentence: what is wrong or missing>\n\n")
+	sb.WriteString("Rules:\n")
+	sb.WriteString("- Output only the verdict line above. No prose, no headings, no lists.\n")
+	sb.WriteString("- PASS only if the fix fully addresses ALL findings below without introducing new defects.\n")
+	sb.WriteString("- FAIL if the fix is incomplete, incorrect, introduces a regression, or makes unrelated changes.\n\n")
+	sb.WriteString("--- Findings that were supposed to be fixed ---\n")
+	sb.WriteString(findings)
+	sb.WriteString("\n\n--- Fix diff (git show HEAD) ---\n")
+	sb.WriteString(diff)
+	return sb.String()
+}
+
+// ExtractVerifyVerdict parses PASS or FAIL from a verifier response.
+// Defaults to FAIL (fail-safe) if neither token is found.
+func ExtractVerifyVerdict(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(strings.ToUpper(line))
+		if strings.HasPrefix(line, "PASS") {
+			return "PASS"
+		}
+		if strings.HasPrefix(line, "FAIL") {
+			return "FAIL"
+		}
+	}
+	return "FAIL"
+}
+
 // BuildReviewPrompt builds a commit review prompt with SOLID/DRY checks.
 func BuildReviewPrompt(hash, subject, body, diff string) string {
 	var sb strings.Builder


### PR DESCRIPTION
## Summary
- Adds `--verifier-model N` flag to select a second independent model that verifies each auto-fix before it's accepted
- `verifyFixStep` inserted after `autoFixStep`: sends fix diff + finding summary to verifier model
- On FAIL: fix commit is reverted with `git revert HEAD` and loop re-reviews from scratch (no sleep)
- On PASS: loop continues normally
- Zero-value verifier (default `--verifier-model 0`) = disabled; fully backward compatible

## Usage
```bash
./opencode-review --model 1 --verifier-model 2 --audit --loop --auto-fix --issues --merge
```

## Closes
Closes #96

## Test plan
- [ ] Build passes: `go build ./...`
- [ ] Tests pass: `go test ./...`
- [ ] Run with `--verifier-model` pointing to a different model, observe `--- Independent Verification ---` section after each fix
- [ ] Run without `--verifier-model` (default), verify behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)