### PR TITLE
fix: error handling hardening + .env file support

### DIFF
--- a/cli/cmd/envfile.go
+++ b/cli/cmd/envfile.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/talk/opencode-client/internal/git"
+)
+
+// loadEnvFile reads KEY=VALUE pairs from .opencode-review.env (fallback: .env)
+// in the given directory. Returns nil if no file is found.
+func loadEnvFile(dir string) map[string]string {
+	for _, name := range []string{".opencode-review.env", ".env"} {
+		path := filepath.Join(dir, name)
+		f, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		defer f.Close()
+		return parseEnvFile(f)
+	}
+	return nil
+}
+
+func parseEnvFile(f *os.File) map[string]string {
+	m := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		m[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	return m
+}
+
+// prescanDir extracts --dir / -dir value from os.Args before flag.Parse().
+func prescanDir() string {
+	args := os.Args[1:]
+	for i, arg := range args {
+		if (arg == "--dir" || arg == "-dir") && i+1 < len(args) {
+			return args[i+1]
+		}
+		for _, prefix := range []string{"--dir=", "-dir="} {
+			if strings.HasPrefix(arg, prefix) {
+				return strings.TrimPrefix(arg, prefix)
+			}
+		}
+	}
+	return ""
+}
+
+// resolveRootForEnv resolves the git repo root for .env lookup.
+// Falls back to dir itself if git lookup fails.
+func resolveRootForEnv(dir string) string {
+	if dir == "" {
+		dir, _ = os.Getwd()
+	}
+	root, err := git.ResolveRepoRoot(dir)
+	if err != nil {
+		return dir
+	}
+	return root
+}
+
+func envOr(env map[string]string, key, fallback string) string {
+	if v, ok := env[key]; ok && v != "" {
+		return v
+	}
+	return fallback
+}
+
+func envBool(env map[string]string, key string, fallback bool) bool {
+	v, ok := env[key]
+	if !ok {
+		return fallback
+	}
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "true", "1", "yes":
+		return true
+	case "false", "0", "no":
+		return false
+	}
+	return fallback
+}
+
+func envInt(env map[string]string, key string, fallback int) int {
+	v, ok := env[key]
+	if !ok {
+		return fallback
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(v))
+	if err != nil {
+		return fallback
+	}
+	return n
+}
+
+func envDuration(env map[string]string, key string, fallback time.Duration) time.Duration {
+	v, ok := env[key]
+	if !ok {
+		return fallback
+	}
+	d, err := time.ParseDuration(strings.TrimSpace(v))
+	if err != nil {
+		return fallback
+	}
+	return d
+}

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -82,24 +82,27 @@ func run() error {
 }
 
 func parseFlags() runConfig {
-	serverURL := flag.String("url", "http://localhost:4096", "Opencode server URL")
+	// Load .env defaults before registering flags so CLI flags override them.
+	env := loadEnvFile(resolveRootForEnv(prescanDir()))
+
+	serverURL := flag.String("url", envOr(env, "URL", "http://localhost:4096"), "Opencode server URL")
 	dirFlag := flag.String("dir", "", "Git repo directory (default: current directory)")
-	modelNum := flag.Int("model", 0, "Model number from list (skips interactive selection)")
+	modelNum := flag.Int("model", envInt(env, "MODEL", 0), "Model number from list (skips interactive selection)")
 	commitRef := flag.String("commit", "HEAD", "Git ref to review (hash, branch, tag)")
-	auditMode := flag.Bool("audit", false, "Full SOLID/DRY audit of entire codebase instead of single commit review")
-	postPR := flag.Bool("pr", false, "Post review as GitHub PR comment")
-	createIssues := flag.Bool("issues", false, "Create GitHub issues for each finding")
-	loopMode := flag.Bool("loop", false, "Keep reviewing latest HEAD until APPROVE, then merge and close issues")
-	autoFix := flag.Bool("auto-fix", false, "Automatically apply AI fixes between loop iterations (requires --loop)")
-	mergeOnApprove := flag.Bool("merge", false, "Merge PR immediately if this review is APPROVE (one-shot)")
-	mergeStrategy := flag.String("merge-strategy", types.DefaultMergeStrategy, fmt.Sprintf("Merge strategy: %s", types.AllowedMergeStrategies()))
-	deleteBranch := flag.Bool("delete-branch", false, "Delete branch after merge")
-	loopInterval := flag.Duration("loop-interval", 30*time.Second, "Wait between loop iterations")
-	baseBranch := flag.String("base", "master", "Base branch for auto-created PRs")
-	createBranch := flag.Bool("create-branch", false, "Create a new fix branch from current HEAD and push before opening PR")
-	validateIssues := flag.Bool("validate-issues", false, "Check open issues against current code and close stale ones before fixing")
-	minConfidence := flag.String("min-confidence", "MEDIUM", "Minimum confidence level to auto-fix: HIGH, MEDIUM, or LOW")
-	verifierModelNum := flag.Int("verifier-model", 0, "Model number to use as independent fix verifier (0 = disabled)")
+	auditMode := flag.Bool("audit", envBool(env, "AUDIT", false), "Full SOLID/DRY audit of entire codebase instead of single commit review")
+	postPR := flag.Bool("pr", envBool(env, "PR", false), "Post review as GitHub PR comment")
+	createIssues := flag.Bool("issues", envBool(env, "ISSUES", false), "Create GitHub issues for each finding")
+	loopMode := flag.Bool("loop", envBool(env, "LOOP", false), "Keep reviewing latest HEAD until APPROVE, then merge and close issues")
+	autoFix := flag.Bool("auto-fix", envBool(env, "AUTO_FIX", false), "Automatically apply AI fixes between loop iterations (requires --loop)")
+	mergeOnApprove := flag.Bool("merge", envBool(env, "MERGE", false), "Merge PR immediately if this review is APPROVE (one-shot)")
+	mergeStrategy := flag.String("merge-strategy", envOr(env, "MERGE_STRATEGY", types.DefaultMergeStrategy), fmt.Sprintf("Merge strategy: %s", types.AllowedMergeStrategies()))
+	deleteBranch := flag.Bool("delete-branch", envBool(env, "DELETE_BRANCH", false), "Delete branch after merge")
+	loopInterval := flag.Duration("loop-interval", envDuration(env, "LOOP_INTERVAL", 30*time.Second), "Wait between loop iterations")
+	baseBranch := flag.String("base", envOr(env, "BASE", "master"), "Base branch for auto-created PRs")
+	createBranch := flag.Bool("create-branch", envBool(env, "CREATE_BRANCH", false), "Create a new fix branch from current HEAD and push before opening PR")
+	validateIssues := flag.Bool("validate-issues", envBool(env, "VALIDATE_ISSUES", false), "Check open issues against current code and close stale ones before fixing")
+	minConfidence := flag.String("min-confidence", envOr(env, "MIN_CONFIDENCE", "MEDIUM"), "Minimum confidence level to auto-fix: HIGH, MEDIUM, or LOW")
+	verifierModelNum := flag.Int("verifier-model", envInt(env, "VERIFIER_MODEL", 0), "Model number to use as independent fix verifier (0 = disabled)")
 	flag.Parse()
 
 	return runConfig{

--- a/cli/cmd/run_loop.go
+++ b/cli/cmd/run_loop.go
@@ -47,6 +47,8 @@ type loopState struct {
 	iteration    int
 	result       iterationResult
 	openIssues   []int
+	// changedFiles is written by autoFixStep and read by reviewStep.
+	// Steps execute sequentially in a single goroutine — no synchronisation needed.
 	changedFiles map[string]bool
 	lastFixPaths []string
 	stop         bool

--- a/cli/internal/github/client.go
+++ b/cli/internal/github/client.go
@@ -224,7 +224,9 @@ func MergePR(ctx context.Context, gh *gogithub.Client, owner, repo string, prNum
 	if deleteBranch {
 		pr, _, err2 := gh.PullRequests.Get(ctx, owner, repo, prNum)
 		if err2 == nil && pr.Head != nil && pr.Head.Ref != nil {
-			gh.Git.DeleteRef(ctx, owner, repo, "heads/"+pr.Head.GetRef()) //nolint
+			if _, err2 = gh.Git.DeleteRef(ctx, owner, repo, "heads/"+pr.Head.GetRef()); err2 != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to delete branch %q: %v\n", pr.Head.GetRef(), err2)
+			}
 		}
 	}
 	return nil
@@ -336,6 +338,12 @@ func ValidateIssues(ctx context.Context, gh *gogithub.Client, owner, repo, repoR
 			lineCount++
 		}
 		f.Close()
+		if err := scanner.Err(); err != nil {
+			v.Valid = true
+			v.Reason = fmt.Sprintf("could not fully read %q: %v — assuming still valid", relFile, err)
+			results = append(results, v)
+			continue
+		}
 
 		if startLine > lineCount {
 			v.Valid = false

--- a/cli/internal/logger/logger.go
+++ b/cli/internal/logger/logger.go
@@ -32,9 +32,18 @@ func (l *Logger) Write(record any) {
 	if l.f == nil {
 		return
 	}
-	b, _ := json.Marshal(record)
-	l.f.Write(b)
-	l.f.Write([]byte("\n"))
+	b, err := json.Marshal(record)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: log marshal error: %v\n", err)
+		return
+	}
+	if _, err := l.f.Write(b); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: log write error: %v\n", err)
+		return
+	}
+	if _, err := l.f.Write([]byte("\n")); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: log write error: %v\n", err)
+	}
 }
 
 // Close flushes and closes the log file.

--- a/cli/internal/opencode/client.go
+++ b/cli/internal/opencode/client.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	sdk "github.com/sst/opencode-sdk-go"
 	"github.com/sst/opencode-sdk-go/option"
@@ -91,10 +92,14 @@ func streamSession(client *sdk.Client, ctx context.Context, repoRoot string, sel
 	}
 	sessionID := session.ID
 	defer func() {
-		client.Session.Delete(ctx, sessionID, sdk.SessionDeleteParams{}) //nolint
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cleanupCancel()
+		client.Session.Delete(cleanupCtx, sessionID, sdk.SessionDeleteParams{}) //nolint
 	}()
 
-	idleCh := make(chan string, 2)
+	// Buffer of 3 ensures consumeSessionEvents never blocks on send:
+	// idle event + stream-error fallback + edge-case rapid session-error then stream-close.
+	idleCh := make(chan string, 3)
 	streamCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	stream := client.Event.ListStreaming(streamCtx, sdk.EventListParams{
@@ -346,7 +351,10 @@ func stageCommitPushFixes(repoRoot string, findings []types.Finding, iteration i
 	if _, err := git.Run(repoRoot, commitArgs...); err != nil {
 		return fixPersistResult{}, runFixError{Context: "  git commit failed", Err: err}
 	}
-	branch, _ := git.Run(repoRoot, "rev-parse", "--abbrev-ref", "HEAD")
+	branch, err := git.Run(repoRoot, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return fixPersistResult{}, runFixError{Context: "  git branch resolution failed", Err: err}
+	}
 	if _, err := git.Run(repoRoot, "push", "origin", branch); err != nil {
 		return fixPersistResult{}, runFixError{Context: "  git push failed", Err: err}
 	}


### PR DESCRIPTION
## Summary
- **8 bug fixes** addressing silent failures in logger, GitHub client, and opencode client
- **New feature**: `.env` / `.opencode-review.env` file support — no more long CLI flags every run

## Bug Fixes
| # | File | Fix |
|---|------|-----|
| #1 | `github/client.go` | Check `scanner.Err()` after line counting — prevents false stale-issue closures |
| #2 | `opencode/client.go` | Return error on git branch resolution failure before push |
| #3 | `logger/logger.go` | Check `json.Marshal` error — no more silent log drops |
| #4 | `logger/logger.go` | Check `f.Write` errors — warn on disk-full etc |
| #5 | `opencode/client.go` | Document `idleCh` buffer size rationale |
| #6 | `opencode/client.go` | Use `context.Background()+5s` for session cleanup — prevents orphaned sessions |
| #7 | `run_loop.go` | Safety comment on `changedFiles` sequential access |
| #8 | `github/client.go` | Log `DeleteRef` failure instead of swallowing |

## .env Feature
Create `.opencode-review.env` in your repo root:
```
MODEL=416
AUDIT=true
LOOP=true
AUTO_FIX=true
ISSUES=true
MERGE=true
MIN_CONFIDENCE=MEDIUM
VERIFIER_MODEL=0
BASE=master
```
CLI flags override .env values. Absent file = identical behavior to before.

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] Create `.opencode-review.env` with `MODEL=1`, run without `--model` flag, verify model 1 is selected
- [ ] Verify no `.env` file = same behavior as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)